### PR TITLE
Optimized Laravel 6 compatibility

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -34,9 +34,7 @@ class Plugin extends PluginBase
         return [
             'functions' => [
                 'd' => function () {
-                    array_map(function ($x) {
-                        (new Dumper)->dump($x);
-                    }, func_get_args());
+                    \dump(func_get_args());
                 }
             ]
         ];

--- a/Plugin.php
+++ b/Plugin.php
@@ -34,7 +34,7 @@ class Plugin extends PluginBase
         return [
             'functions' => [
                 'd' => function () {
-                    \dump(func_get_args());
+                    \dump(...func_get_args());
                 }
             ]
         ];


### PR DESCRIPTION
The `Illuminate\Support\Debug\Dumper` class is no longer available in Laravel 6.

Maybe we should just re-use the global `dump` function registered by the `symfony/var-dumper` to be compatible with future changes?

This PR was tested on October 1.1 and 1.0.

It does change the output from the default Laravel `light` theme, to a `dark` output.
There is a way to set the styles on the `VarDumper` but it cannot be specified via the `dump` helper.

Before:
![image](https://user-images.githubusercontent.com/8600029/93182606-2e967e80-f73a-11ea-8559-e1eed8ad9d6a.png)

After:
![image](https://user-images.githubusercontent.com/8600029/93182679-45d56c00-f73a-11ea-822d-d8400ce8ffaa.png)


